### PR TITLE
fix: move tokenLineNumber increment to inside the EOF if

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -44,7 +44,6 @@ func (t token) debug(description string) {
 	for i < len(t.lc.source) {
 		r := t.lc.source[i]
 
-		tokenLineNumber++
 		if i < t.location {
 			tokenColumn++
 		}
@@ -52,6 +51,7 @@ func (t token) debug(description string) {
 		tokenLine = append(tokenLine, r)
 
 		if r == '\n' {
+			tokenLineNumber++
 			// Got to the end of the line that the token is in.
 			if inTokenLine {
 				// Now outside the loop, `tokenLine`


### PR DESCRIPTION
The problem:
```cmd
./livescheme examples/bad_parse_missing_closing_paren.scm 
Expected closing paren [at line 3, column 1 in file examples/bad_parse_missing_closing_paren.scm]
 ```
The token line count is wrong, the error message is being reporting on line 3, but the missing parentheses is on line 2
